### PR TITLE
fixed #1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "range_bounds_map"
-version = "0.0.6"
+version = "0.1.0"
 dependencies = [
  "either",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "range_bounds_map"
-version = "0.0.6"
+version = "0.1.0"
 authors = ["James Forster <james.forsterer@gmail.com>"]
 edition = "2021"
 description = """

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ topic area:
 - <https://docs.rs/rangemap>
   Very similar to this crate but can only use [`Range`]s and
   [`RangeInclusive`]s as keys in it's `map` and `set` structs (separately).
+- <https://docs.rs/btree-range-map>
 - <https://docs.rs/ranges>
   Cool library for fully-generic ranges (unlike std::ops ranges), along
   with a `Ranges` datastructure for storing them (Vec-based

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -1529,9 +1529,9 @@ where
 		return Ok(output);
 	}
 
-    /// Similar to [`RangeBoundsMap::overlapping()`] except the
-    /// `(Bound, Bound)`s returned in the iterator have been
-    /// trimmed/cut by the given `range_bounds`.
+	/// Similar to [`RangeBoundsMap::overlapping()`] except the
+	/// `(Bound, Bound)`s returned in the iterator have been
+	/// trimmed/cut by the given `range_bounds`.
 	///
 	/// This is sort of the analogue to the AND function between a
 	/// `RangeBounds` AND a [`RangeBoundsMap`].
@@ -1737,7 +1737,7 @@ where
 	K: RangeBounds<I> + Serialize,
 	V: Serialize,
 {
-    #[trivial]
+	#[trivial]
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
@@ -1756,7 +1756,7 @@ where
 	I: Ord + Clone,
 	V: Deserialize<'de>,
 {
-    #[trivial]
+	#[trivial]
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
@@ -1783,12 +1783,12 @@ where
 {
 	type Value = RangeBoundsMap<I, K, V>;
 
-    #[trivial]
+	#[trivial]
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 		formatter.write_str("a RangeBoundsMap")
 	}
 
-    #[trivial]
+	#[trivial]
 	fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
 	where
 		A: MapAccess<'de>,

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -1013,7 +1013,7 @@ where
 	I: Ord + Clone,
 	K: RangeBounds<I> + Serialize,
 {
-    #[trivial]
+	#[trivial]
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
@@ -1031,7 +1031,7 @@ where
 	K: Deserialize<'de> + RangeBounds<I>,
 	I: Ord + Clone,
 {
-    #[trivial]
+	#[trivial]
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
@@ -1055,12 +1055,12 @@ where
 {
 	type Value = RangeBoundsSet<I, K>;
 
-    #[trivial]
+	#[trivial]
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 		formatter.write_str("a RangeBoundsSet")
 	}
 
-    #[trivial]
+	#[trivial]
 	fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
 	where
 		A: SeqAccess<'de>,

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -492,7 +492,7 @@ where
 	pub fn gaps_same<'a, Q>(
 		&'a self,
 		outer_range_bounds: &'a Q,
-	) -> impl Iterator<Item = Result<K, TryFromBoundsError>> + '_
+	) -> impl Iterator<Item = Result<K, TryFromBoundsError>> + 'a
 	where
 		Q: RangeBounds<I>,
 		K: TryFromBounds<I>,
@@ -837,6 +837,81 @@ where
 			.split_off(start_bound)
 			.map(|map| map.into_iter().map(first).collect())
 	}
+
+	/// Similar to [`RangeBoundsSet::overlapping()`] except the
+	/// `(Bound, Bound)`s returned in the iterator have been
+	/// trimmed/cut by the given `range_bounds`.
+	///
+	/// This is sort of the analogue to the AND function between a
+	/// `RangeBounds` AND a [`RangeBoundsSet`].
+	///
+	/// # Examples
+	/// ```
+	/// use std::ops::Bound;
+	///
+	/// use range_bounds_map::RangeBoundsSet;
+	///
+	/// let range_bounds_set =
+	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	///
+	/// let mut overlapping_trimmed =
+	/// 	range_bounds_set.overlapping_trimmed(&(2..20));
+	///
+	/// assert_eq!(
+	/// 	overlapping_trimmed.collect::<Vec<_>>(),
+	/// 	[
+	/// 		(Bound::Included(&2), Bound::Excluded(&4)),
+	/// 		(Bound::Included(&4), Bound::Excluded(&8)),
+	/// 		(Bound::Included(&8), Bound::Excluded(&20)),
+	/// 	]
+	/// );
+	/// ```
+	#[trivial]
+	pub fn overlapping_trimmed<'a, Q>(
+		&'a self,
+		range_bounds: &'a Q,
+	) -> impl DoubleEndedIterator<Item = (Bound<&I>, Bound<&I>)>
+	where
+		Q: RangeBounds<I>,
+	{
+		self.map.overlapping_trimmed(range_bounds).map(first)
+	}
+
+	/// Identical to [`RangeBoundsSet::overlapping_trimmed()`] except
+	/// it returns an iterator of `Result<RangeBounds,
+	/// TryFromBoundsError>`.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
+	///
+	/// let range_bounds_set =
+	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	///
+	/// let mut overlapping_trimmed_same =
+	/// 	range_bounds_set.overlapping_trimmed_same(&(2..=20));
+	///
+	/// assert_eq!(
+	/// 	overlapping_trimmed_same.collect::<Vec<_>>(),
+	/// 	[
+	/// 		Ok(2..4),
+	/// 		Ok(4..8),
+	/// 		// Due to using a RangeInclusive in `overlapping_trimmed_same()`
+	/// 		Err(TryFromBoundsError),
+	/// 	]
+	/// );
+	/// ```
+	#[trivial]
+	pub fn overlapping_trimmed_same<'a, Q>(
+		&'a self,
+		range_bounds: &'a Q,
+	) -> impl DoubleEndedIterator<Item = Result<K, TryFromBoundsError>> + 'a
+	where
+		Q: RangeBounds<I>,
+		K: TryFromBounds<I>,
+	{
+		self.map.overlapping_trimmed_same(range_bounds).map(first)
+	}
 }
 
 impl<const N: usize, I, K> TryFrom<[K; N]> for RangeBoundsSet<I, K>
@@ -938,6 +1013,7 @@ where
 	I: Ord + Clone,
 	K: RangeBounds<I> + Serialize,
 {
+    #[trivial]
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
@@ -955,6 +1031,7 @@ where
 	K: Deserialize<'de> + RangeBounds<I>,
 	I: Ord + Clone,
 {
+    #[trivial]
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: Deserializer<'de>,
@@ -978,10 +1055,12 @@ where
 {
 	type Value = RangeBoundsSet<I, K>;
 
+    #[trivial]
 	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
 		formatter.write_str("a RangeBoundsSet")
 	}
 
+    #[trivial]
 	fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
 	where
 		A: SeqAccess<'de>,

--- a/todo.md
+++ b/todo.md
@@ -8,6 +8,8 @@
   some reason(?)
 - take a look around idiomatic rust for a bit
 - review method parameter names for all public functions
+- make try_from_bounds trait return TryFromBoundsError rather than
+  mapping the option all the time
 
 # optimisations
 
@@ -18,6 +20,8 @@
 
 - replace `RangeBounds` with `K` where applicatble in docs
 - replace rust types URL links with direct rust links
+- add a # Panics section to every method that can panic, probably most
+  given invalid RangeBounds
 
 # features
 
@@ -33,7 +37,7 @@
 
 - should we implement FromIterator? If so which insert should we use?
   (At the moment we do implement it using insert_platonic())
-- should append_* functions not change the base if they fail half way?
+- should append\_\* functions not change the base if they fail half way?
 
 #### PUBLISH
 


### PR DESCRIPTION
This PR implements `overlapping_trimmed()` and `overlapping_trimmed_same()` to fix #1.