### PR TITLE
Revert "Remove Implementations of `FromIterator` and other `From<other_collection>` traits"

### DIFF
--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -1738,6 +1738,56 @@ where
 	}
 }
 
+impl<const N: usize, I, K, V> TryFrom<[(K, V); N]> for RangeBoundsMap<I, K, V>
+where
+	K: RangeBounds<I>,
+	I: Ord + Clone,
+{
+	type Error = OverlapError;
+	#[trivial]
+	fn try_from(pairs: [(K, V); N]) -> Result<Self, Self::Error> {
+		let mut range_bounds_map = RangeBoundsMap::new();
+		for (range_bounds, value) in pairs {
+			range_bounds_map.insert_strict(range_bounds, value)?;
+		}
+
+		return Ok(range_bounds_map);
+	}
+}
+impl<I, K, V> TryFrom<Vec<(K, V)>> for RangeBoundsMap<I, K, V>
+where
+	K: RangeBounds<I>,
+	I: Ord + Clone,
+{
+	type Error = OverlapError;
+	#[trivial]
+	fn try_from(pairs: Vec<(K, V)>) -> Result<Self, Self::Error> {
+		let mut range_bounds_map = RangeBoundsMap::new();
+		for (range_bounds, value) in pairs {
+			range_bounds_map.insert_strict(range_bounds, value)?;
+		}
+
+		return Ok(range_bounds_map);
+	}
+}
+
+impl<I, K, V> FromIterator<(K, V)> for RangeBoundsMap<I, K, V>
+where
+	K: RangeBounds<I>,
+	I: Ord + Clone,
+{
+	#[trivial]
+	fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+		let mut output = RangeBoundsMap::new();
+
+		for (range_bounds, value) in iter {
+			output.insert_strict(range_bounds, value).unwrap();
+		}
+
+		return output;
+	}
+}
+
 impl<I, K, V> IntoIterator for RangeBoundsMap<I, K, V>
 where
 	K: RangeBounds<I>,

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -1016,6 +1016,55 @@ where
 	}
 }
 
+impl<const N: usize, I, K> TryFrom<[K; N]> for RangeBoundsSet<I, K>
+where
+	K: RangeBounds<I>,
+	I: Ord + Clone,
+{
+	type Error = OverlapError;
+	#[trivial]
+	fn try_from(pairs: [K; N]) -> Result<Self, Self::Error> {
+		let mut range_bounds_set = RangeBoundsSet::new();
+		for range_bounds in pairs {
+			range_bounds_set.insert_strict(range_bounds)?;
+		}
+
+		return Ok(range_bounds_set);
+	}
+}
+impl<I, K> TryFrom<Vec<K>> for RangeBoundsSet<I, K>
+where
+	K: RangeBounds<I>,
+	I: Ord + Clone,
+{
+	type Error = OverlapError;
+	#[trivial]
+	fn try_from(pairs: Vec<K>) -> Result<Self, Self::Error> {
+		let mut range_bounds_set = RangeBoundsSet::new();
+		for range_bounds in pairs {
+			range_bounds_set.insert_strict(range_bounds)?;
+		}
+
+		return Ok(range_bounds_set);
+	}
+}
+
+impl<I, K> FromIterator<K> for RangeBoundsSet<I, K>
+where
+	K: RangeBounds<I>,
+	I: Ord + Clone,
+{
+	#[trivial]
+	fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
+		let mut output = RangeBoundsSet::new();
+
+		for range_bounds in iter {
+			output.insert_strict(range_bounds).unwrap();
+		}
+
+		return output;
+	}
+}
 impl<I, K> IntoIterator for RangeBoundsSet<I, K>
 where
 	K: RangeBounds<I>,


### PR DESCRIPTION
Reverts ripytide/range_bounds_map#16

Some errors came up that I'd like to fix before merging.