### PR TITLE
Remove Implementations of `FromIterator` and other `From<other_collection>` traits (PR 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ based on [`RangeBoundsMap`].
 ```rust
 use range_bounds_map::RangeBoundsMap;
 
-let mut range_bounds_map = RangeBoundsMap::new();
+let mut map = RangeBoundsMap::new();
 
-range_bounds_map.insert_strict(0..5, true);
-range_bounds_map.insert_strict(5..10, false);
+map.insert_strict(0..5, true);
+map.insert_strict(5..10, false);
 
-assert_eq!(range_bounds_map.overlaps(&(-2..12)), true);
-assert_eq!(range_bounds_map.contains_point(&20), false);
-assert_eq!(range_bounds_map.contains_point(&5), true);
+assert_eq!(map.overlaps(&(-2..12)), true);
+assert_eq!(map.contains_point(&20), false);
+assert_eq!(map.contains_point(&5), true);
 ```
 
 ## Example using a custom [`RangeBounds`] type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,14 @@ along with range_bounds_map. If not, see <https://www.gnu.org/licenses/>.
 //! ```rust
 //! use range_bounds_map::RangeBoundsMap;
 //!
-//! let mut range_bounds_map = RangeBoundsMap::new();
+//! let mut map = RangeBoundsMap::new();
 //!
-//! range_bounds_map.insert_strict(0..5, true);
-//! range_bounds_map.insert_strict(5..10, false);
+//! map.insert_strict(0..5, true);
+//! map.insert_strict(5..10, false);
 //!
-//! assert_eq!(range_bounds_map.overlaps(&(-2..12)), true);
-//! assert_eq!(range_bounds_map.contains_point(&20), false);
-//! assert_eq!(range_bounds_map.contains_point(&5), true);
+//! assert_eq!(map.overlaps(&(-2..12)), true);
+//! assert_eq!(map.contains_point(&20), false);
+//! assert_eq!(map.contains_point(&5), true);
 //! ```
 //!
 //! ## Example using a custom [`RangeBounds`] type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ along with range_bounds_map. If not, see <https://www.gnu.org/licenses/>.
 //! }
 //!
 //! // Next we can create a custom typed RangeBoundsMap
-//! let reservation_map = RangeBoundsMap::try_from([
+//! let reservation_map = RangeBoundsMap::from_slice_strict([
 //! 	(Reservation::Finite(10, 20), "Ferris".to_string()),
 //! 	(Reservation::Infinite(20), "Corro".to_string()),
 //! ])

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -166,7 +166,7 @@ pub struct OverlapError;
 /// let mut map =
 /// 	RangeBoundsMap::from_slice_strict([(2..8, true)]).unwrap();
 ///
-/// assert!(range_bounds_map.cut(&(4..=6)).is_err());
+/// assert!(map.cut(&(4..=6)).is_err());
 /// ```
 ///
 /// # Example with `insert_merge_*` functions.
@@ -252,7 +252,7 @@ pub struct OverlapError;
 /// .unwrap();
 ///
 /// assert_eq!(
-/// 	range_bounds_map.insert_merge_touching(
+/// 	map.insert_merge_touching(
 /// 		MultiBounds::Exclusive(4, 6),
 /// 		false
 /// 	),
@@ -303,9 +303,9 @@ where
 	///
 	/// let mut map = RangeBoundsMap::new();
 	///
-	/// assert_eq!(range_bounds_map.len(), 0);
-	/// range_bounds_map.insert_strict(0..1, false).unwrap();
-	/// assert_eq!(range_bounds_map.len(), 1);
+	/// assert_eq!(map.len(), 0);
+	/// map.insert_strict(0..1, false).unwrap();
+	/// assert_eq!(map.len(), 1);
 	/// ```
 	#[trivial]
 	pub fn len(&self) -> usize {
@@ -321,9 +321,9 @@ where
 	///
 	/// let mut map = RangeBoundsMap::new();
 	///
-	/// assert_eq!(range_bounds_map.is_empty(), true);
-	/// range_bounds_map.insert_strict(0..1, false).unwrap();
-	/// assert_eq!(range_bounds_map.is_empty(), false);
+	/// assert_eq!(map.is_empty(), true);
+	/// map.insert_strict(0..1, false).unwrap();
+	/// assert_eq!(map.is_empty(), false);
 	/// ```
 	#[trivial]
 	pub fn is_empty(&self) -> bool {
@@ -350,12 +350,9 @@ where
 	///
 	/// let mut map = RangeBoundsMap::new();
 	///
-	/// assert_eq!(range_bounds_map.insert_strict(5..10, 9), Ok(()));
-	/// assert_eq!(
-	/// 	range_bounds_map.insert_strict(5..10, 2),
-	/// 	Err(OverlapError)
-	/// );
-	/// assert_eq!(range_bounds_map.len(), 1);
+	/// assert_eq!(map.insert_strict(5..10, 9), Ok(()));
+	/// assert_eq!(map.insert_strict(5..10, 2), Err(OverlapError));
+	/// assert_eq!(map.len(), 1);
 	/// ```
 	#[tested]
 	pub fn insert_strict(
@@ -395,13 +392,13 @@ where
 	///
 	/// let mut map = RangeBoundsMap::new();
 	///
-	/// range_bounds_map.insert_strict(5..10, false);
+	/// map.insert_strict(5..10, false);
 	///
-	/// assert_eq!(range_bounds_map.overlaps(&(1..=3)), false);
-	/// assert_eq!(range_bounds_map.overlaps(&(4..5)), false);
+	/// assert_eq!(map.overlaps(&(1..=3)), false);
+	/// assert_eq!(map.overlaps(&(4..5)), false);
 	///
-	/// assert_eq!(range_bounds_map.overlaps(&(4..=5)), true);
-	/// assert_eq!(range_bounds_map.overlaps(&(4..6)), true);
+	/// assert_eq!(map.overlaps(&(4..=5)), true);
+	/// assert_eq!(map.overlaps(&(4..6)), true);
 	/// ```
 	#[trivial]
 	pub fn overlaps<Q>(&self, range_bounds: &Q) -> bool
@@ -433,7 +430,7 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// let mut overlapping = range_bounds_map.overlapping(&(2..8));
+	/// let mut overlapping = map.overlapping(&(2..8));
 	///
 	/// assert_eq!(
 	/// 	overlapping.collect::<Vec<_>>(),
@@ -508,9 +505,9 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// assert_eq!(range_bounds_map.get_at_point(&3), Some(&false));
-	/// assert_eq!(range_bounds_map.get_at_point(&4), Some(&true));
-	/// assert_eq!(range_bounds_map.get_at_point(&101), None);
+	/// assert_eq!(map.get_at_point(&3), Some(&false));
+	/// assert_eq!(map.get_at_point(&4), Some(&true));
+	/// assert_eq!(map.get_at_point(&101), None);
 	/// ```
 	#[trivial]
 	pub fn get_at_point(&self, point: &I) -> Option<&V> {
@@ -531,9 +528,9 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// assert_eq!(range_bounds_map.contains_point(&3), true);
-	/// assert_eq!(range_bounds_map.contains_point(&4), true);
-	/// assert_eq!(range_bounds_map.contains_point(&101), false);
+	/// assert_eq!(map.contains_point(&3), true);
+	/// assert_eq!(map.contains_point(&4), true);
+	/// assert_eq!(map.contains_point(&101), false);
 	/// ```
 	#[trivial]
 	pub fn contains_point(&self, point: &I) -> bool {
@@ -550,11 +547,11 @@ where
 	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
-	/// if let Some(x) = range_bounds_map.get_at_point_mut(&2) {
+	/// if let Some(x) = map.get_at_point_mut(&2) {
 	/// 	*x = true;
 	/// }
 	///
-	/// assert_eq!(range_bounds_map.get_at_point(&1), Some(&true));
+	/// assert_eq!(map.get_at_point(&1), Some(&true));
 	/// ```
 	#[tested]
 	pub fn get_at_point_mut(&mut self, point: &I) -> Option<&mut V> {
@@ -584,15 +581,9 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// assert_eq!(
-	/// 	range_bounds_map.get_entry_at_point(&3),
-	/// 	Some((&(1..4), &false))
-	/// );
-	/// assert_eq!(
-	/// 	range_bounds_map.get_entry_at_point(&4),
-	/// 	Some((&(4..8), &true))
-	/// );
-	/// assert_eq!(range_bounds_map.get_entry_at_point(&101), None);
+	/// assert_eq!(map.get_entry_at_point(&3), Some((&(1..4), &false)));
+	/// assert_eq!(map.get_entry_at_point(&4), Some((&(4..8), &true)));
+	/// assert_eq!(map.get_entry_at_point(&101), None);
 	/// ```
 	#[trivial]
 	pub fn get_entry_at_point(&self, point: &I) -> Option<(&K, &V)> {
@@ -619,7 +610,7 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// let mut iter = range_bounds_map.iter();
+	/// let mut iter = map.iter();
 	///
 	/// assert_eq!(iter.next(), Some((&(1..4), &false)));
 	/// assert_eq!(iter.next(), Some((&(4..8), &true)));
@@ -653,17 +644,14 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// let mut removed = range_bounds_map.remove_overlapping(&(2..8));
+	/// let mut removed = map.remove_overlapping(&(2..8));
 	///
 	/// assert_eq!(
 	/// 	removed.collect::<Vec<_>>(),
 	/// 	[(1..4, false), (4..8, true)]
 	/// );
 	///
-	/// assert_eq!(
-	/// 	range_bounds_map.iter().collect::<Vec<_>>(),
-	/// 	[(&(8..100), &false)]
-	/// );
+	/// assert_eq!(map.iter().collect::<Vec<_>>(), [(&(8..100), &false)]);
 	/// ```
 	#[tested]
 	pub fn remove_overlapping<Q>(
@@ -917,7 +905,7 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// let mut gaps = range_bounds_map.gaps(&(2..));
+	/// let mut gaps = map.gaps(&(2..));
 	///
 	/// assert_eq!(
 	/// 	gaps.collect::<Vec<_>>(),
@@ -1018,7 +1006,7 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// let mut gaps_same = range_bounds_map.gaps_same(&(2..));
+	/// let mut gaps_same = map.gaps_same(&(2..));
 	///
 	/// assert_eq!(
 	/// 	gaps_same.collect::<Vec<_>>(),
@@ -1061,15 +1049,9 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// assert_eq!(range_bounds_map.contains_range_bounds(&(1..3)), true);
-	/// assert_eq!(
-	/// 	range_bounds_map.contains_range_bounds(&(2..6)),
-	/// 	false
-	/// );
-	/// assert_eq!(
-	/// 	range_bounds_map.contains_range_bounds(&(6..50)),
-	/// 	true
-	/// );
+	/// assert_eq!(map.contains_range_bounds(&(1..3)), true);
+	/// assert_eq!(map.contains_range_bounds(&(2..6)), false);
+	/// assert_eq!(map.contains_range_bounds(&(6..50)), true);
 	/// ```
 	#[trivial]
 	pub fn contains_range_bounds<Q>(&self, range_bounds: &Q) -> bool
@@ -1114,25 +1096,22 @@ where
 	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
-	/// assert_eq!(
-	/// 	range_bounds_map.insert_merge_touching(4..6, true),
-	/// 	Ok(&(1..6))
-	/// );
+	/// assert_eq!(map.insert_merge_touching(4..6, true), Ok(&(1..6)));
 	///
 	/// // Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_map.insert_merge_touching(4..8, false),
+	/// 	map.insert_merge_touching(4..8, false),
 	/// 	Err(OverlapOrTryFromBoundsError::Overlap(OverlapError)),
 	/// );
 	///
 	/// // Neither Touching or Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_map.insert_merge_touching(10..16, false),
+	/// 	map.insert_merge_touching(10..16, false),
 	/// 	Ok(&(10..16))
 	/// );
 	///
 	/// assert_eq!(
-	/// 	range_bounds_map.iter().collect::<Vec<_>>(),
+	/// 	map.iter().collect::<Vec<_>>(),
 	/// 	[(&(1..6), &true), (&(10..16), &false)]
 	/// );
 	/// ```
@@ -1245,24 +1224,21 @@ where
 	///
 	/// // Touching
 	/// assert_eq!(
-	/// 	range_bounds_map.insert_merge_overlapping(-4..1, true),
+	/// 	map.insert_merge_overlapping(-4..1, true),
 	/// 	Ok(&(-4..1))
 	/// );
 	///
 	/// // Overlapping
-	/// assert_eq!(
-	/// 	range_bounds_map.insert_merge_overlapping(2..8, true),
-	/// 	Ok(&(1..8))
-	/// );
+	/// assert_eq!(map.insert_merge_overlapping(2..8, true), Ok(&(1..8)));
 	///
 	/// // Neither Touching or Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_map.insert_merge_overlapping(10..16, false),
+	/// 	map.insert_merge_overlapping(10..16, false),
 	/// 	Ok(&(10..16))
 	/// );
 	///
 	/// assert_eq!(
-	/// 	range_bounds_map.iter().collect::<Vec<_>>(),
+	/// 	map.iter().collect::<Vec<_>>(),
 	/// 	[(&(-4..1), &true), (&(1..8), &true), (&(10..16), &false)]
 	/// );
 	/// ```
@@ -1350,27 +1326,24 @@ where
 	///
 	/// // Touching
 	/// assert_eq!(
-	/// 	range_bounds_map
-	/// 		.insert_merge_touching_or_overlapping(-4..1, true),
+	/// 	map.insert_merge_touching_or_overlapping(-4..1, true),
 	/// 	Ok(&(-4..4))
 	/// );
 	///
 	/// // Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_map
-	/// 		.insert_merge_touching_or_overlapping(2..8, true),
+	/// 	map.insert_merge_touching_or_overlapping(2..8, true),
 	/// 	Ok(&(-4..8))
 	/// );
 	///
 	/// // Neither Touching or Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_map
-	/// 		.insert_merge_touching_or_overlapping(10..16, false),
+	/// 	map.insert_merge_touching_or_overlapping(10..16, false),
 	/// 	Ok(&(10..16))
 	/// );
 	///
 	/// assert_eq!(
-	/// 	range_bounds_map.iter().collect::<Vec<_>>(),
+	/// 	map.iter().collect::<Vec<_>>(),
 	/// 	[(&(-4..8), &true), (&(10..16), &false)]
 	/// );
 	/// ```
@@ -1432,10 +1405,10 @@ where
 	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(2..8, false)]).unwrap();
 	///
-	/// assert_eq!(range_bounds_map.insert_overwrite(4..6, true), Ok(()));
+	/// assert_eq!(map.insert_overwrite(4..6, true), Ok(()));
 	///
 	/// assert_eq!(
-	/// 	range_bounds_map.iter().collect::<Vec<_>>(),
+	/// 	map.iter().collect::<Vec<_>>(),
 	/// 	[(&(2..4), &false), (&(4..6), &true), (&(6..8), &false)]
 	/// );
 	/// ```
@@ -1469,10 +1442,7 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// assert_eq!(
-	/// 	range_bounds_map.first_entry(),
-	/// 	Some((&(1..4), &false))
-	/// );
+	/// assert_eq!(map.first_entry(), Some((&(1..4), &false)));
 	/// ```
 	#[trivial]
 	pub fn first_entry(&self) -> Option<(&K, &V)> {
@@ -1494,7 +1464,7 @@ where
 	/// .unwrap();
 	///
 	/// assert_eq!(
-	/// 	range_bounds_map.last_entry(),
+	/// 	map.last_entry(),
 	/// 	Some((&(8..100), &false))
 	/// );
 	#[trivial]
@@ -1651,8 +1621,7 @@ where
 	/// ])
 	/// .unwrap();
 	///
-	/// let mut overlapping_trimmed =
-	/// 	range_bounds_map.overlapping_trimmed(&(2..20));
+	/// let mut overlapping_trimmed = map.overlapping_trimmed(&(2..20));
 	///
 	/// assert_eq!(
 	/// 	overlapping_trimmed.collect::<Vec<_>>(),
@@ -1714,7 +1683,7 @@ where
 	/// .unwrap();
 	///
 	/// let mut overlapping_trimmed_same =
-	/// 	range_bounds_map.overlapping_trimmed_same(&(2..=20));
+	/// 	map.overlapping_trimmed_same(&(2..=20));
 	///
 	/// assert_eq!(
 	/// 	overlapping_trimmed_same.collect::<Vec<_>>(),
@@ -1744,20 +1713,20 @@ where
 		})
 	}
 
-    /// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
-    /// `Value`) pairs from the slice into the map using
-    /// [`RangeBoundsMap::insert_strict()`].
-    ///
+	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
+	/// `Value`) pairs from the slice into the map using
+	/// [`RangeBoundsMap::insert_strict()`].
+	///
 	/// If any of the given `RangeBounds` overlap any of the other
 	/// `RangeBounds` in the slice, then an [`OverlapError`] is
 	/// returned.
 	///
 	/// # Panics
 	///
-    /// Panics if any of the given `RangeBounds` is an invalid
-    /// `RangeBounds`. See [`Invalid
-    /// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
-    /// for more details.
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
 	///
 	/// # Examples
 	/// ```
@@ -2605,13 +2574,12 @@ mod tests {
 		assert_gaps(basic(), ii(8, 8), [ii(8, 8)]);
 	}
 	fn assert_gaps<const N: usize>(
-		range_bounds_map: RangeBoundsMap<u8, TestBounds, bool>,
+		map: RangeBoundsMap<u8, TestBounds, bool>,
 		outer_range_bounds: TestBounds,
 		result: [TestBounds; N],
 	) {
 		assert_eq!(
-			range_bounds_map
-				.gaps(&outer_range_bounds)
+			map.gaps(&outer_range_bounds)
 				.map(|(start, end)| (start.cloned(), end.cloned()))
 				.collect::<Vec<_>>(),
 			result

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -1744,11 +1744,10 @@ where
 	) -> Result<RangeBoundsMap<I, K, V>, OverlapError> {
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
-			map.insert_strict(range_bounds, value).unwrap();
+			map.insert_strict(range_bounds, value)?;
 		}
 		return Ok(map);
 	}
-
 	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
 	/// `Value`) pairs from the slice into the map using
 	/// [`RangeBoundsMap::insert_merge_touching()`].
@@ -1777,17 +1776,16 @@ where
 	#[trivial]
 	pub fn from_slice_merge_touching<const N: usize>(
 		slice: [(K, V); N],
-	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	) -> Result<RangeBoundsMap<I, K, V>, OverlapOrTryFromBoundsError>
 	where
 		K: TryFromBounds<I>,
 	{
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
-			map.insert_merge_touching(range_bounds, value).unwrap();
+			map.insert_merge_touching(range_bounds, value)?;
 		}
 		return Ok(map);
 	}
-
 	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
 	/// `Value`) pairs from the slice into the map using
 	/// [`RangeBoundsMap::insert_merge_overlapping()`].
@@ -1816,17 +1814,16 @@ where
 	#[trivial]
 	pub fn from_slice_merge_overlapping<const N: usize>(
 		slice: [(K, V); N],
-	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	) -> Result<RangeBoundsMap<I, K, V>, TryFromBoundsError>
 	where
 		K: TryFromBounds<I>,
 	{
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
-			map.insert_merge_overlapping(range_bounds, value).unwrap();
+			map.insert_merge_overlapping(range_bounds, value)?;
 		}
 		return Ok(map);
 	}
-
 	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
 	/// `Value`) pairs from the slice into the map using
 	/// [`RangeBoundsMap::insert_merge_touching_or_overlapping()`].
@@ -1857,18 +1854,16 @@ where
 	#[trivial]
 	pub fn from_slice_merge_touching_or_overlapping<const N: usize>(
 		slice: [(K, V); N],
-	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	) -> Result<RangeBoundsMap<I, K, V>, TryFromBoundsError>
 	where
 		K: TryFromBounds<I>,
 	{
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
-			map.insert_merge_touching_or_overlapping(range_bounds, value)
-				.unwrap();
+			map.insert_merge_touching_or_overlapping(range_bounds, value)?;
 		}
 		return Ok(map);
 	}
-
 	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
 	/// `Value`) pairs from the slice into the map using
 	/// [`RangeBoundsMap::insert_overwrite()`].
@@ -1897,14 +1892,14 @@ where
 	#[trivial]
 	pub fn from_slice_overwrite<const N: usize>(
 		slice: [(K, V); N],
-	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	) -> Result<RangeBoundsMap<I, K, V>, TryFromBoundsError>
 	where
 		V: Clone,
 		K: TryFromBounds<I>,
 	{
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
-			map.insert_overwrite(range_bounds, value).unwrap();
+			map.insert_overwrite(range_bounds, value)?;
 		}
 		return Ok(map);
 	}

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -1717,9 +1717,8 @@ where
 	/// `Value`) pairs from the slice into the map using
 	/// [`RangeBoundsMap::insert_strict()`].
 	///
-	/// If any of the given `RangeBounds` overlap any of the other
-	/// `RangeBounds` in the slice, then an [`OverlapError`] is
-	/// returned.
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsMap::insert_strict()`] for details.
 	///
 	/// # Panics
 	///
@@ -1746,6 +1745,166 @@ where
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
 			map.insert_strict(range_bounds, value).unwrap();
+		}
+		return Ok(map);
+	}
+
+	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
+	/// `Value`) pairs from the slice into the map using
+	/// [`RangeBoundsMap::insert_merge_touching()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsMap::insert_merge_touching()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
+	///
+	/// let map = RangeBoundsMap::from_slice_merge_touching([
+	/// 	(1..4, false),
+	/// 	(4..8, true),
+	/// 	(8..100, false),
+	/// ])
+	/// .unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_merge_touching<const N: usize>(
+		slice: [(K, V); N],
+	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut map = RangeBoundsMap::new();
+		for (range_bounds, value) in slice {
+			map.insert_merge_touching(range_bounds, value).unwrap();
+		}
+		return Ok(map);
+	}
+
+	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
+	/// `Value`) pairs from the slice into the map using
+	/// [`RangeBoundsMap::insert_merge_overlapping()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsMap::insert_merge_overlapping()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
+	///
+	/// let map = RangeBoundsMap::from_slice_merge_overlapping([
+	/// 	(1..4, false),
+	/// 	(4..8, true),
+	/// 	(8..100, false),
+	/// ])
+	/// .unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_merge_overlapping<const N: usize>(
+		slice: [(K, V); N],
+	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut map = RangeBoundsMap::new();
+		for (range_bounds, value) in slice {
+			map.insert_merge_overlapping(range_bounds, value).unwrap();
+		}
+		return Ok(map);
+	}
+
+	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
+	/// `Value`) pairs from the slice into the map using
+	/// [`RangeBoundsMap::insert_merge_touching_or_overlapping()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsMap::insert_merge_touching_or_overlapping()`] for
+	/// details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
+	///
+	/// let map =
+	/// 	RangeBoundsMap::from_slice_merge_touching_or_overlapping([
+	/// 		(1..4, false),
+	/// 		(4..8, true),
+	/// 		(8..100, false),
+	/// 	])
+	/// 	.unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_merge_touching_or_overlapping<const N: usize>(
+		slice: [(K, V); N],
+	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut map = RangeBoundsMap::new();
+		for (range_bounds, value) in slice {
+			map.insert_merge_touching_or_overlapping(range_bounds, value)
+				.unwrap();
+		}
+		return Ok(map);
+	}
+
+	/// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
+	/// `Value`) pairs from the slice into the map using
+	/// [`RangeBoundsMap::insert_overwrite()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsMap::overwrite()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
+	///
+	/// let map = RangeBoundsMap::from_slice_overwrite([
+	/// 	(1..4, false),
+	/// 	(4..8, true),
+	/// 	(8..100, false),
+	/// ])
+	/// .unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_overwrite<const N: usize>(
+		slice: [(K, V); N],
+	) -> Result<RangeBoundsMap<I, K, V>, OverlapError>
+	where
+		V: Clone,
+		K: TryFromBounds<I>,
+	{
+		let mut map = RangeBoundsMap::new();
+		for (range_bounds, value) in slice {
+			map.insert_overwrite(range_bounds, value).unwrap();
 		}
 		return Ok(map);
 	}

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -1754,7 +1754,7 @@ where
 	) -> Result<RangeBoundsMap<I, K, V>, OverlapError> {
 		let mut map = RangeBoundsMap::new();
 		for (range_bounds, value) in slice {
-			map.insert_strict(range_bounds, value);
+			map.insert_strict(range_bounds, value).unwrap();
 		}
 		return Ok(map);
 	}
@@ -2369,11 +2369,14 @@ mod tests {
 				range_bounds_map.insert_strict(inside_range, ()).unwrap();
 
 				let mut result = RangeBoundsMap::new();
-				for resulting_entry in range_bounds_map
-					.overlapping_trimmed(&overlap_range)
-					.map(|(key, value)| (cloned_bounds(key), value.clone()))
+				for (resulting_range_bounds, resulting_value) in
+					range_bounds_map
+						.overlapping_trimmed(&overlap_range)
+						.map(|(key, value)| (cloned_bounds(key), value.clone()))
 				{
-					result.insert_strict(resulting_entry.0, resulting_entry.1);
+					result
+						.insert_strict(resulting_range_bounds, resulting_value)
+						.unwrap();
 				}
 
 				for i in NUMBERS_DOMAIN {
@@ -2395,11 +2398,14 @@ mod tests {
 				range_bounds_map.insert_strict(inside_range2, ()).unwrap();
 
 				let mut result = RangeBoundsMap::new();
-				for resulting_entry in range_bounds_map
-					.overlapping_trimmed(&overlap_range)
-					.map(|(key, value)| (cloned_bounds(key), value.clone()))
+				for (resulting_range_bounds, resulting_value) in
+					range_bounds_map
+						.overlapping_trimmed(&overlap_range)
+						.map(|(key, value)| (cloned_bounds(key), value.clone()))
 				{
-					result.insert_strict(resulting_entry.0, resulting_entry.1);
+					result
+						.insert_strict(resulting_range_bounds, resulting_value)
+						.unwrap();
 				}
 
 				for i in NUMBERS_DOMAIN {

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -163,7 +163,7 @@ pub struct OverlapError;
 /// ```
 /// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 ///
-/// let mut range_bounds_map =
+/// let mut map =
 /// 	RangeBoundsMap::from_slice_strict([(2..8, true)]).unwrap();
 ///
 /// assert!(range_bounds_map.cut(&(4..=6)).is_err());
@@ -245,7 +245,7 @@ pub struct OverlapError;
 /// 	}
 /// }
 ///
-/// let mut range_bounds_map = RangeBoundsMap::from_slice_strict([(
+/// let mut map = RangeBoundsMap::from_slice_strict([(
 /// 	MultiBounds::Inclusive(2, 4),
 /// 	true,
 /// )])
@@ -285,7 +285,7 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map: RangeBoundsMap<u8, Range<u8>, bool> =
+	/// let map: RangeBoundsMap<u8, Range<u8>, bool> =
 	/// 	RangeBoundsMap::new();
 	/// ```
 	#[trivial]
@@ -301,7 +301,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map = RangeBoundsMap::new();
+	/// let mut map = RangeBoundsMap::new();
 	///
 	/// assert_eq!(range_bounds_map.len(), 0);
 	/// range_bounds_map.insert_strict(0..1, false).unwrap();
@@ -319,7 +319,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map = RangeBoundsMap::new();
+	/// let mut map = RangeBoundsMap::new();
 	///
 	/// assert_eq!(range_bounds_map.is_empty(), true);
 	/// range_bounds_map.insert_strict(0..1, false).unwrap();
@@ -334,8 +334,8 @@ where
 	/// modifying other entries.
 	///
 	/// If the given `RangeBounds` overlaps one or more `RangeBounds`
-	/// already in the map rather than just touching, then an
-	/// [`OverlapError`] is returned and the map is not updated.
+	/// already in the map, then an [`OverlapError`] is returned and
+	/// the map is not updated.
 	///
 	/// # Panics
 	///
@@ -348,7 +348,7 @@ where
 	/// ```
 	/// use range_bounds_map::{OverlapError, RangeBoundsMap};
 	///
-	/// let mut range_bounds_map = RangeBoundsMap::new();
+	/// let mut map = RangeBoundsMap::new();
 	///
 	/// assert_eq!(range_bounds_map.insert_strict(5..10, 9), Ok(()));
 	/// assert_eq!(
@@ -393,7 +393,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map = RangeBoundsMap::new();
+	/// let mut map = RangeBoundsMap::new();
 	///
 	/// range_bounds_map.insert_strict(5..10, false);
 	///
@@ -426,7 +426,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -501,7 +501,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -524,7 +524,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -547,7 +547,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map =
+	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// if let Some(x) = range_bounds_map.get_at_point_mut(&2) {
@@ -577,7 +577,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -612,7 +612,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -646,7 +646,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let mut map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -910,7 +910,7 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..3, false),
 	/// 	(5..7, true),
 	/// 	(9..100, false),
@@ -1011,7 +1011,7 @@ where
 	///
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..3, false),
 	/// 	(5..7, true),
 	/// 	(9..100, false),
@@ -1054,7 +1054,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..3, false),
 	/// 	(5..8, true),
 	/// 	(8..100, false),
@@ -1090,9 +1090,8 @@ where
 	/// `RangeBounds` is returned.
 	///
 	/// If the given `RangeBounds` overlaps one or more `RangeBounds`
-	/// already in the map rather than just touching, then an
-	/// [`OverlapError`] is returned and the map is not updated.
-	/// `RangeBounds` is returned.
+	/// already in the map, then an [`OverlapError`] is returned and
+	/// the map is not updated.
 	///
 	/// If the merged `RangeBounds` cannot be created with the
 	/// [`TryFromBounds`] trait then a [`TryFromBoundsError`] will be
@@ -1111,7 +1110,7 @@ where
 	/// 	OverlapError, OverlapOrTryFromBoundsError, RangeBoundsMap,
 	/// };
 	///
-	/// let mut range_bounds_map =
+	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
@@ -1241,7 +1240,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map =
+	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
@@ -1346,7 +1345,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map =
+	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
@@ -1430,7 +1429,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map =
+	/// let mut map =
 	/// 	RangeBoundsMap::from_slice_strict([(2..8, false)]).unwrap();
 	///
 	/// assert_eq!(range_bounds_map.insert_overwrite(4..6, true), Ok(()));
@@ -1463,7 +1462,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1487,7 +1486,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1645,7 +1644,7 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1707,7 +1706,7 @@ where
 	/// ```
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
+	/// let map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1745,9 +1744,32 @@ where
 		})
 	}
 
-	/// Allocate a `RangeBoundsMap` and move the given `RangeBounds`
-	/// in the slice into the map using
-	/// [`RangeBoundsMap::insert_strict()`].
+    /// Allocate a `RangeBoundsMap` and move the given (`RangeBounds`,
+    /// `Value`) pairs from the slice into the map using
+    /// [`RangeBoundsMap::insert_strict()`].
+    ///
+	/// If any of the given `RangeBounds` overlap any of the other
+	/// `RangeBounds` in the slice, then an [`OverlapError`] is
+	/// returned.
+	///
+	/// # Panics
+	///
+    /// Panics if any of the given `RangeBounds` is an invalid
+    /// `RangeBounds`. See [`Invalid
+    /// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+    /// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
+	///
+	/// let map = RangeBoundsMap::from_slice_strict([
+	/// 	(1..4, false),
+	/// 	(4..8, true),
+	/// 	(8..100, false),
+	/// ])
+	/// .unwrap();
+	/// ```
 	#[trivial]
 	pub fn from_slice_strict<const N: usize>(
 		slice: [(K, V); N],
@@ -1867,13 +1889,12 @@ where
 	where
 		A: MapAccess<'de>,
 	{
-		let mut range_bounds_map = RangeBoundsMap::new();
+		let mut map = RangeBoundsMap::new();
 		while let Some((range_bounds, value)) = access.next_entry()? {
-			range_bounds_map
-				.insert_strict(range_bounds, value)
+			map.insert_strict(range_bounds, value)
 				.map_err(|_| serde::de::Error::custom("RangeBounds overlap"))?;
 		}
-		Ok(range_bounds_map)
+		Ok(map)
 	}
 }
 
@@ -2283,15 +2304,15 @@ mod tests {
 		//case one
 		for overlap_range in all_valid_test_bounds() {
 			for inside_range in all_valid_test_bounds() {
-				let mut range_bounds_map = RangeBoundsMap::new();
-				range_bounds_map.insert_strict(inside_range, ()).unwrap();
+				let mut map = RangeBoundsMap::new();
+				map.insert_strict(inside_range, ()).unwrap();
 
 				let mut expected_overlapping = Vec::new();
 				if overlaps(&overlap_range, &inside_range) {
 					expected_overlapping.push(inside_range);
 				}
 
-				let overlapping = range_bounds_map
+				let overlapping = map
 					.overlapping(&overlap_range)
 					.map(|(key, _)| key)
 					.copied()
@@ -2312,9 +2333,9 @@ mod tests {
 			for (inside_range1, inside_range2) in
 				all_non_overlapping_test_bound_pairs()
 			{
-				let mut range_bounds_map = RangeBoundsMap::new();
-				range_bounds_map.insert_strict(inside_range1, ()).unwrap();
-				range_bounds_map.insert_strict(inside_range2, ()).unwrap();
+				let mut map = RangeBoundsMap::new();
+				map.insert_strict(inside_range1, ()).unwrap();
+				map.insert_strict(inside_range2, ()).unwrap();
 
 				let mut expected_overlapping = Vec::new();
 				if overlaps(&overlap_range, &inside_range1) {
@@ -2332,7 +2353,7 @@ mod tests {
 					}
 				}
 
-				let overlapping = range_bounds_map
+				let overlapping = map
 					.overlapping(&overlap_range)
 					.map(|(key, _)| key)
 					.copied()
@@ -2365,14 +2386,13 @@ mod tests {
 		//case one
 		for overlap_range in all_valid_test_bounds() {
 			for inside_range in all_valid_test_bounds() {
-				let mut range_bounds_map = RangeBoundsMap::new();
-				range_bounds_map.insert_strict(inside_range, ()).unwrap();
+				let mut map = RangeBoundsMap::new();
+				map.insert_strict(inside_range, ()).unwrap();
 
 				let mut result = RangeBoundsMap::new();
-				for (resulting_range_bounds, resulting_value) in
-					range_bounds_map
-						.overlapping_trimmed(&overlap_range)
-						.map(|(key, value)| (cloned_bounds(key), value.clone()))
+				for (resulting_range_bounds, resulting_value) in map
+					.overlapping_trimmed(&overlap_range)
+					.map(|(key, value)| (cloned_bounds(key), value.clone()))
 				{
 					result
 						.insert_strict(resulting_range_bounds, resulting_value)
@@ -2393,15 +2413,14 @@ mod tests {
 			for (inside_range1, inside_range2) in
 				all_non_overlapping_test_bound_pairs()
 			{
-				let mut range_bounds_map = RangeBoundsMap::new();
-				range_bounds_map.insert_strict(inside_range1, ()).unwrap();
-				range_bounds_map.insert_strict(inside_range2, ()).unwrap();
+				let mut map = RangeBoundsMap::new();
+				map.insert_strict(inside_range1, ()).unwrap();
+				map.insert_strict(inside_range2, ()).unwrap();
 
 				let mut result = RangeBoundsMap::new();
-				for (resulting_range_bounds, resulting_value) in
-					range_bounds_map
-						.overlapping_trimmed(&overlap_range)
-						.map(|(key, value)| (cloned_bounds(key), value.clone()))
+				for (resulting_range_bounds, resulting_value) in map
+					.overlapping_trimmed(&overlap_range)
+					.map(|(key, value)| (cloned_bounds(key), value.clone()))
 				{
 					result
 						.insert_strict(resulting_range_bounds, resulting_value)

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -1738,56 +1738,6 @@ where
 	}
 }
 
-impl<const N: usize, I, K, V> TryFrom<[(K, V); N]> for RangeBoundsMap<I, K, V>
-where
-	K: RangeBounds<I>,
-	I: Ord + Clone,
-{
-	type Error = OverlapError;
-	#[trivial]
-	fn try_from(pairs: [(K, V); N]) -> Result<Self, Self::Error> {
-		let mut range_bounds_map = RangeBoundsMap::new();
-		for (range_bounds, value) in pairs {
-			range_bounds_map.insert_strict(range_bounds, value)?;
-		}
-
-		return Ok(range_bounds_map);
-	}
-}
-impl<I, K, V> TryFrom<Vec<(K, V)>> for RangeBoundsMap<I, K, V>
-where
-	K: RangeBounds<I>,
-	I: Ord + Clone,
-{
-	type Error = OverlapError;
-	#[trivial]
-	fn try_from(pairs: Vec<(K, V)>) -> Result<Self, Self::Error> {
-		let mut range_bounds_map = RangeBoundsMap::new();
-		for (range_bounds, value) in pairs {
-			range_bounds_map.insert_strict(range_bounds, value)?;
-		}
-
-		return Ok(range_bounds_map);
-	}
-}
-
-impl<I, K, V> FromIterator<(K, V)> for RangeBoundsMap<I, K, V>
-where
-	K: RangeBounds<I>,
-	I: Ord + Clone,
-{
-	#[trivial]
-	fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-		let mut output = RangeBoundsMap::new();
-
-		for (range_bounds, value) in iter {
-			output.insert_strict(range_bounds, value).unwrap();
-		}
-
-		return output;
-	}
-}
-
 impl<I, K, V> IntoIterator for RangeBoundsMap<I, K, V>
 where
 	K: RangeBounds<I>,

--- a/src/range_bounds_map.rs
+++ b/src/range_bounds_map.rs
@@ -50,7 +50,7 @@ use crate::TryFromBounds;
 /// use range_bounds_map::RangeBoundsMap;
 ///
 /// // Make a map of ranges to booleans
-/// let mut map = RangeBoundsMap::try_from([
+/// let mut map = RangeBoundsMap::from_slice_strict([
 /// 	(4..8, false),
 /// 	(8..18, true),
 /// 	(20..100, false),
@@ -164,7 +164,7 @@ pub struct OverlapError;
 /// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 ///
 /// let mut range_bounds_map =
-/// 	RangeBoundsMap::try_from([(2..8, true)]).unwrap();
+/// 	RangeBoundsMap::from_slice_strict([(2..8, true)]).unwrap();
 ///
 /// assert!(range_bounds_map.cut(&(4..=6)).is_err());
 /// ```
@@ -245,7 +245,7 @@ pub struct OverlapError;
 /// 	}
 /// }
 ///
-/// let mut range_bounds_map = RangeBoundsMap::try_from([(
+/// let mut range_bounds_map = RangeBoundsMap::from_slice_strict([(
 /// 	MultiBounds::Inclusive(2, 4),
 /// 	true,
 /// )])
@@ -426,7 +426,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -501,7 +501,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -524,7 +524,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -548,7 +548,7 @@ where
 	/// use range_bounds_map::RangeBoundsMap;
 	///
 	/// let mut range_bounds_map =
-	/// 	RangeBoundsMap::try_from([(1..4, false)]).unwrap();
+	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// if let Some(x) = range_bounds_map.get_at_point_mut(&2) {
 	/// 	*x = true;
@@ -577,7 +577,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -612,7 +612,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -646,7 +646,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut range_bounds_map = RangeBoundsMap::try_from([
+	/// let mut range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -719,16 +719,18 @@ where
 	///
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let mut base = RangeBoundsMap::try_from([
+	/// let mut base = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
 	/// ])
 	/// .unwrap();
 	///
-	/// let after_cut =
-	/// 	RangeBoundsMap::try_from([(1..2, false), (40..100, false)])
-	/// 		.unwrap();
+	/// let after_cut = RangeBoundsMap::from_slice_strict([
+	/// 	(1..2, false),
+	/// 	(40..100, false),
+	/// ])
+	/// .unwrap();
 	///
 	/// assert_eq!(
 	/// 	base.cut(&(2..40)).unwrap().collect::<Vec<_>>(),
@@ -846,16 +848,18 @@ where
 	/// ```
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let mut base = RangeBoundsMap::try_from([
+	/// let mut base = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
 	/// ])
 	/// .unwrap();
 	///
-	/// let after_cut =
-	/// 	RangeBoundsMap::try_from([(1..2, false), (40..100, false)])
-	/// 		.unwrap();
+	/// let after_cut = RangeBoundsMap::from_slice_strict([
+	/// 	(1..2, false),
+	/// 	(40..100, false),
+	/// ])
+	/// .unwrap();
 	///
 	/// assert_eq!(
 	/// 	base.cut_same(&(2..40)).unwrap().collect::<Vec<_>>(),
@@ -906,7 +910,7 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..3, false),
 	/// 	(5..7, true),
 	/// 	(9..100, false),
@@ -1007,7 +1011,7 @@ where
 	///
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..3, false),
 	/// 	(5..7, true),
 	/// 	(9..100, false),
@@ -1050,7 +1054,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..3, false),
 	/// 	(5..8, true),
 	/// 	(8..100, false),
@@ -1108,7 +1112,7 @@ where
 	/// };
 	///
 	/// let mut range_bounds_map =
-	/// 	RangeBoundsMap::try_from([(1..4, false)]).unwrap();
+	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -1238,7 +1242,7 @@ where
 	/// use range_bounds_map::RangeBoundsMap;
 	///
 	/// let mut range_bounds_map =
-	/// 	RangeBoundsMap::try_from([(1..4, false)]).unwrap();
+	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -1343,7 +1347,7 @@ where
 	/// use range_bounds_map::RangeBoundsMap;
 	///
 	/// let mut range_bounds_map =
-	/// 	RangeBoundsMap::try_from([(1..4, false)]).unwrap();
+	/// 	RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -1427,7 +1431,7 @@ where
 	/// use range_bounds_map::RangeBoundsMap;
 	///
 	/// let mut range_bounds_map =
-	/// 	RangeBoundsMap::try_from([(2..8, false)]).unwrap();
+	/// 	RangeBoundsMap::from_slice_strict([(2..8, false)]).unwrap();
 	///
 	/// assert_eq!(range_bounds_map.insert_overwrite(4..6, true), Ok(()));
 	///
@@ -1459,7 +1463,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1483,7 +1487,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1512,15 +1516,19 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let mut base =
-	/// 	RangeBoundsMap::try_from([(1..4, false), (4..8, true)])
-	/// 		.unwrap();
+	/// let mut base = RangeBoundsMap::from_slice_strict([
+	/// 	(1..4, false),
+	/// 	(4..8, true),
+	/// ])
+	/// .unwrap();
 	///
-	/// let mut add =
-	/// 	RangeBoundsMap::try_from([(10..38, true), (40..42, false)])
-	/// 		.unwrap();
+	/// let mut add = RangeBoundsMap::from_slice_strict([
+	/// 	(10..38, true),
+	/// 	(40..42, false),
+	/// ])
+	/// .unwrap();
 	///
-	/// let expected = RangeBoundsMap::try_from([
+	/// let expected = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(10..38, true),
@@ -1564,7 +1572,7 @@ where
 	///
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let mut a = RangeBoundsMap::try_from([
+	/// let mut a = RangeBoundsMap::from_slice_strict([
 	/// 	(1..2, false),
 	/// 	(4..8, true),
 	/// 	(10..16, true),
@@ -1637,7 +1645,7 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsMap;
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1699,7 +1707,7 @@ where
 	/// ```
 	/// use range_bounds_map::{RangeBoundsMap, TryFromBoundsError};
 	///
-	/// let range_bounds_map = RangeBoundsMap::try_from([
+	/// let range_bounds_map = RangeBoundsMap::from_slice_strict([
 	/// 	(1..4, false),
 	/// 	(4..8, true),
 	/// 	(8..100, false),
@@ -1735,6 +1743,20 @@ where
 				value,
 			)
 		})
+	}
+
+	/// Allocate a `RangeBoundsMap` and move the given `RangeBounds`
+	/// in the slice into the map using
+	/// [`RangeBoundsMap::insert_strict()`].
+	#[trivial]
+	pub fn from_slice_strict<const N: usize>(
+		slice: [(K, V); N],
+	) -> Result<RangeBoundsMap<I, K, V>, OverlapError> {
+		let mut map = RangeBoundsMap::new();
+		for (range_bounds, value) in slice {
+			map.insert_strict(range_bounds, value);
+		}
+		return Ok(map);
 	}
 }
 
@@ -2119,7 +2141,7 @@ mod tests {
 		&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
 	fn basic() -> RangeBoundsMap<u8, TestBounds, bool> {
-		RangeBoundsMap::try_from([
+		RangeBoundsMap::from_slice_strict([
 			(ui(4), false),
 			(ee(5, 7), true),
 			(ii(7, 7), false),
@@ -2129,7 +2151,7 @@ mod tests {
 	}
 
 	fn special() -> RangeBoundsMap<u8, MultiBounds, bool> {
-		RangeBoundsMap::try_from([
+		RangeBoundsMap::from_slice_strict([
 			(mii(4, 6), false),
 			(mee(7, 8), true),
 			(mii(8, 12), false),
@@ -2236,7 +2258,10 @@ mod tests {
 		assert_eq!(before.insert_strict(to_insert.0, to_insert.1), result);
 		match after {
 			Some(after) => {
-				assert_eq!(before, RangeBoundsMap::try_from(after).unwrap())
+				assert_eq!(
+					before,
+					RangeBoundsMap::from_slice_strict(after).unwrap()
+				)
 			}
 			None => assert_eq!(before, clone),
 		}
@@ -2343,10 +2368,13 @@ mod tests {
 				let mut range_bounds_map = RangeBoundsMap::new();
 				range_bounds_map.insert_strict(inside_range, ()).unwrap();
 
-				let result = range_bounds_map
+				let mut result = RangeBoundsMap::new();
+				for resulting_entry in range_bounds_map
 					.overlapping_trimmed(&overlap_range)
 					.map(|(key, value)| (cloned_bounds(key), value.clone()))
-					.collect::<RangeBoundsMap<u8, TestBounds, ()>>();
+				{
+					result.insert_strict(resulting_entry.0, resulting_entry.1);
+				}
 
 				for i in NUMBERS_DOMAIN {
 					assert_eq!(
@@ -2366,10 +2394,13 @@ mod tests {
 				range_bounds_map.insert_strict(inside_range1, ()).unwrap();
 				range_bounds_map.insert_strict(inside_range2, ()).unwrap();
 
-				let result = range_bounds_map
+				let mut result = RangeBoundsMap::new();
+				for resulting_entry in range_bounds_map
 					.overlapping_trimmed(&overlap_range)
 					.map(|(key, value)| (cloned_bounds(key), value.clone()))
-					.collect::<RangeBoundsMap<u8, TestBounds, ()>>();
+				{
+					result.insert_strict(resulting_entry.0, resulting_entry.1);
+				}
 
 				for i in NUMBERS_DOMAIN {
 					assert_eq!(
@@ -2423,7 +2454,10 @@ mod tests {
 		);
 		match after {
 			Some(after) => {
-				assert_eq!(before, RangeBoundsMap::try_from(after).unwrap())
+				assert_eq!(
+					before,
+					RangeBoundsMap::from_slice_strict(after).unwrap()
+				)
 			}
 			None => assert_eq!(before, clone),
 		}
@@ -2523,7 +2557,10 @@ mod tests {
 		}
 		match after {
 			Some(after) => {
-				assert_eq!(before, RangeBoundsMap::try_from(after).unwrap())
+				assert_eq!(
+					before,
+					RangeBoundsMap::from_slice_strict(after).unwrap()
+				)
 			}
 			None => assert_eq!(before, clone),
 		}
@@ -2663,7 +2700,10 @@ mod tests {
 		);
 		match after {
 			Some(after) => {
-				assert_eq!(before, RangeBoundsMap::try_from(after).unwrap())
+				assert_eq!(
+					before,
+					RangeBoundsMap::from_slice_strict(after).unwrap()
+				)
 			}
 			None => assert_eq!(before, clone),
 		}
@@ -2766,7 +2806,10 @@ mod tests {
 		);
 		match after {
 			Some(after) => {
-				assert_eq!(before, RangeBoundsMap::try_from(after).unwrap())
+				assert_eq!(
+					before,
+					RangeBoundsMap::from_slice_strict(after).unwrap()
+				)
 			}
 			None => assert_eq!(before, clone),
 		}
@@ -2775,7 +2818,7 @@ mod tests {
 	#[test]
 	fn insert_merge_touching_or_overlapping_tests() {
 		assert_insert_merge_touching_or_overlapping(
-			RangeBoundsMap::try_from([(1..4, false)]).unwrap(),
+			RangeBoundsMap::from_slice_strict([(1..4, false)]).unwrap(),
 			(-4..1, true),
 			Ok(&(-4..4)),
 			Some([(-4..4, true)]),
@@ -2899,7 +2942,10 @@ mod tests {
 		);
 		match after {
 			Some(after) => {
-				assert_eq!(before, RangeBoundsMap::try_from(after).unwrap())
+				assert_eq!(
+					before,
+					RangeBoundsMap::from_slice_strict(after).unwrap()
+				)
 			}
 			None => assert_eq!(before, clone),
 		}

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -130,8 +130,7 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set: RangeBoundsSet<u8, Range<u8>> =
-	/// 	RangeBoundsSet::new();
+	/// let set: RangeBoundsSet<u8, Range<u8>> = RangeBoundsSet::new();
 	/// ```
 	#[trivial]
 	pub fn new() -> Self {
@@ -146,7 +145,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set = RangeBoundsSet::new();
+	/// let mut set = RangeBoundsSet::new();
 	///
 	/// assert_eq!(range_bounds_set.len(), 0);
 	/// range_bounds_set.insert_strict(0..1).unwrap();
@@ -164,7 +163,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set = RangeBoundsSet::new();
+	/// let mut set = RangeBoundsSet::new();
 	///
 	/// assert_eq!(range_bounds_set.is_empty(), true);
 	/// range_bounds_set.insert_strict(0..1).unwrap();
@@ -179,8 +178,8 @@ where
 	/// `RangeBounds` in the set.
 	///
 	/// If the given `RangeBounds` overlaps one or more `RangeBounds`
-	/// already in the set rather than just touching, then an
-	/// [`OverlapError`] is returned and the set is not updated.
+	/// already in the set, then an [`OverlapError`] is returned and
+	/// the set is not updated.
 	///
 	/// # Panics
 	///
@@ -193,7 +192,7 @@ where
 	/// ```
 	/// use range_bounds_map::{OverlapError, RangeBoundsSet};
 	///
-	/// let mut range_bounds_set = RangeBoundsSet::new();
+	/// let mut set = RangeBoundsSet::new();
 	///
 	/// assert_eq!(range_bounds_set.insert_strict(5..10), Ok(()));
 	/// assert_eq!(
@@ -224,7 +223,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set = RangeBoundsSet::new();
+	/// let mut set = RangeBoundsSet::new();
 	///
 	/// range_bounds_set.insert_strict(5..10);
 	///
@@ -256,9 +255,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// let mut overlapping = range_bounds_set.overlapping(&(2..8));
 	///
@@ -285,9 +283,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.get_at_point(&3), Some(&(1..4)));
 	/// assert_eq!(range_bounds_set.get_at_point(&4), Some(&(4..8)));
@@ -305,9 +302,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.contains_point(&3), true);
 	/// assert_eq!(range_bounds_set.contains_point(&4), true);
@@ -325,9 +321,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// let mut iter = range_bounds_set.iter();
 	///
@@ -355,7 +350,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set =
+	/// let mut set =
 	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 		.unwrap();
 	///
@@ -501,9 +496,8 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
+	/// 	.unwrap();
 	///
 	/// let mut gaps = range_bounds_set.gaps(&(2..));
 	///
@@ -543,9 +537,8 @@ where
 	///
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
+	/// 	.unwrap();
 	///
 	/// let mut gaps_same = range_bounds_set.gaps_same(&(2..));
 	///
@@ -580,9 +573,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..3, 5..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..3, 5..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.contains_range_bounds(&(1..3)), true);
 	/// assert_eq!(
@@ -609,8 +601,8 @@ where
 	/// `RangeBounds` is returned.
 	///
 	/// If the given `RangeBounds` overlaps one or more `RangeBounds`
-	/// already in the set rather than just touching, then an
-	/// [`OverlapError`] is returned and the set is not updated.
+	/// already in the set, then an [`OverlapError`] is returned and
+	/// the set is not updated.
 	///
 	/// If the merged `RangeBounds` cannot be created with the
 	/// [`TryFromBounds`] trait then a [`TryFromBoundsError`] will be
@@ -629,8 +621,7 @@ where
 	/// 	OverlapError, OverlapOrTryFromBoundsError, RangeBoundsSet,
 	/// };
 	///
-	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4]).unwrap();
+	/// let mut set = RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -687,8 +678,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4]).unwrap();
+	/// let mut set = RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -745,8 +735,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4]).unwrap();
+	/// let mut set = RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -804,8 +793,7 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([2..8]).unwrap();
+	/// let mut set = RangeBoundsSet::from_slice_strict([2..8]).unwrap();
 	///
 	/// assert_eq!(range_bounds_set.insert_overwrite(4..6), Ok(()));
 	///
@@ -831,9 +819,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.first(), Some(&(1..4)));
 	/// ```
@@ -848,9 +835,8 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.last(), Some(&(8..100)));
 	/// ```
@@ -970,9 +956,8 @@ where
 	///
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// let mut overlapping_trimmed =
 	/// 	range_bounds_set.overlapping_trimmed(&(2..20));
@@ -1012,9 +997,8 @@ where
 	/// ```
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
-	/// let range_bounds_set =
-	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
-	/// 		.unwrap();
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
 	///
 	/// let mut overlapping_trimmed_same =
 	/// 	range_bounds_set.overlapping_trimmed_same(&(2..=20));
@@ -1042,8 +1026,27 @@ where
 	}
 
 	/// Allocate a `RangeBoundsSet` and move the given `RangeBounds`
-	/// in the slice into the set using
-	/// [`RangeBoundsMap::insert_strict()`].
+	/// from the slice into the set using
+	/// [`RangeBoundsSet::insert_strict()`].
+	///
+	/// If any of the given `RangeBounds` overlap any of the other
+	/// `RangeBounds` in the slice, then an [`OverlapError`] is
+	/// returned.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
+	///
+	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 	.unwrap();
+	/// ```
 	#[trivial]
 	pub fn from_slice_strict<const N: usize>(
 		slice: [K; N],
@@ -1158,13 +1161,12 @@ where
 	where
 		A: SeqAccess<'de>,
 	{
-		let mut range_bounds_set = RangeBoundsSet::new();
+		let mut set = RangeBoundsSet::new();
 		while let Some(range_bounds) = access.next_element()? {
-			range_bounds_set
-				.insert_strict(range_bounds)
+			set.insert_strict(range_bounds)
 				.map_err(|_| serde::de::Error::custom("RangeBounds overlap"))?;
 		}
-		Ok(range_bounds_set)
+		Ok(set)
 	}
 }
 

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -1016,55 +1016,6 @@ where
 	}
 }
 
-impl<const N: usize, I, K> TryFrom<[K; N]> for RangeBoundsSet<I, K>
-where
-	K: RangeBounds<I>,
-	I: Ord + Clone,
-{
-	type Error = OverlapError;
-	#[trivial]
-	fn try_from(pairs: [K; N]) -> Result<Self, Self::Error> {
-		let mut range_bounds_set = RangeBoundsSet::new();
-		for range_bounds in pairs {
-			range_bounds_set.insert_strict(range_bounds)?;
-		}
-
-		return Ok(range_bounds_set);
-	}
-}
-impl<I, K> TryFrom<Vec<K>> for RangeBoundsSet<I, K>
-where
-	K: RangeBounds<I>,
-	I: Ord + Clone,
-{
-	type Error = OverlapError;
-	#[trivial]
-	fn try_from(pairs: Vec<K>) -> Result<Self, Self::Error> {
-		let mut range_bounds_set = RangeBoundsSet::new();
-		for range_bounds in pairs {
-			range_bounds_set.insert_strict(range_bounds)?;
-		}
-
-		return Ok(range_bounds_set);
-	}
-}
-
-impl<I, K> FromIterator<K> for RangeBoundsSet<I, K>
-where
-	K: RangeBounds<I>,
-	I: Ord + Clone,
-{
-	#[trivial]
-	fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
-		let mut output = RangeBoundsSet::new();
-
-		for range_bounds in iter {
-			output.insert_strict(range_bounds).unwrap();
-		}
-
-		return output;
-	}
-}
 impl<I, K> IntoIterator for RangeBoundsSet<I, K>
 where
 	K: RangeBounds<I>,

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -147,9 +147,9 @@ where
 	///
 	/// let mut set = RangeBoundsSet::new();
 	///
-	/// assert_eq!(range_bounds_set.len(), 0);
-	/// range_bounds_set.insert_strict(0..1).unwrap();
-	/// assert_eq!(range_bounds_set.len(), 1);
+	/// assert_eq!(set.len(), 0);
+	/// set.insert_strict(0..1).unwrap();
+	/// assert_eq!(set.len(), 1);
 	/// ```
 	#[trivial]
 	pub fn len(&self) -> usize {
@@ -165,9 +165,9 @@ where
 	///
 	/// let mut set = RangeBoundsSet::new();
 	///
-	/// assert_eq!(range_bounds_set.is_empty(), true);
-	/// range_bounds_set.insert_strict(0..1).unwrap();
-	/// assert_eq!(range_bounds_set.is_empty(), false);
+	/// assert_eq!(set.is_empty(), true);
+	/// set.insert_strict(0..1).unwrap();
+	/// assert_eq!(set.is_empty(), false);
 	/// ```
 	#[trivial]
 	pub fn is_empty(&self) -> bool {
@@ -194,12 +194,9 @@ where
 	///
 	/// let mut set = RangeBoundsSet::new();
 	///
-	/// assert_eq!(range_bounds_set.insert_strict(5..10), Ok(()));
-	/// assert_eq!(
-	/// 	range_bounds_set.insert_strict(5..10),
-	/// 	Err(OverlapError)
-	/// );
-	/// assert_eq!(range_bounds_set.len(), 1);
+	/// assert_eq!(set.insert_strict(5..10), Ok(()));
+	/// assert_eq!(set.insert_strict(5..10), Err(OverlapError));
+	/// assert_eq!(set.len(), 1);
 	/// ```
 	#[trivial]
 	pub fn insert_strict(
@@ -225,13 +222,13 @@ where
 	///
 	/// let mut set = RangeBoundsSet::new();
 	///
-	/// range_bounds_set.insert_strict(5..10);
+	/// set.insert_strict(5..10);
 	///
-	/// assert_eq!(range_bounds_set.overlaps(&(1..=3)), false);
-	/// assert_eq!(range_bounds_set.overlaps(&(4..5)), false);
+	/// assert_eq!(set.overlaps(&(1..=3)), false);
+	/// assert_eq!(set.overlaps(&(4..5)), false);
 	///
-	/// assert_eq!(range_bounds_set.overlaps(&(4..=5)), true);
-	/// assert_eq!(range_bounds_set.overlaps(&(4..6)), true);
+	/// assert_eq!(set.overlaps(&(4..=5)), true);
+	/// assert_eq!(set.overlaps(&(4..6)), true);
 	/// ```
 	#[trivial]
 	pub fn overlaps<Q>(&self, range_bounds: &Q) -> bool
@@ -258,7 +255,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// let mut overlapping = range_bounds_set.overlapping(&(2..8));
+	/// let mut overlapping = set.overlapping(&(2..8));
 	///
 	/// assert_eq!(
 	/// 	overlapping.collect::<Vec<_>>(),
@@ -286,9 +283,9 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// assert_eq!(range_bounds_set.get_at_point(&3), Some(&(1..4)));
-	/// assert_eq!(range_bounds_set.get_at_point(&4), Some(&(4..8)));
-	/// assert_eq!(range_bounds_set.get_at_point(&101), None);
+	/// assert_eq!(set.get_at_point(&3), Some(&(1..4)));
+	/// assert_eq!(set.get_at_point(&4), Some(&(4..8)));
+	/// assert_eq!(set.get_at_point(&101), None);
 	/// ```
 	#[trivial]
 	pub fn get_at_point(&self, point: &I) -> Option<&K> {
@@ -305,9 +302,9 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// assert_eq!(range_bounds_set.contains_point(&3), true);
-	/// assert_eq!(range_bounds_set.contains_point(&4), true);
-	/// assert_eq!(range_bounds_set.contains_point(&101), false);
+	/// assert_eq!(set.contains_point(&3), true);
+	/// assert_eq!(set.contains_point(&4), true);
+	/// assert_eq!(set.contains_point(&101), false);
 	/// ```
 	#[trivial]
 	pub fn contains_point(&self, point: &I) -> bool {
@@ -324,7 +321,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// let mut iter = range_bounds_set.iter();
+	/// let mut iter = set.iter();
 	///
 	/// assert_eq!(iter.next(), Some(&(1..4)));
 	/// assert_eq!(iter.next(), Some(&(4..8)));
@@ -354,14 +351,11 @@ where
 	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 		.unwrap();
 	///
-	/// let mut removed = range_bounds_set.remove_overlapping(&(2..8));
+	/// let mut removed = set.remove_overlapping(&(2..8));
 	///
 	/// assert_eq!(removed.collect::<Vec<_>>(), [1..4, 4..8]);
 	///
-	/// assert_eq!(
-	/// 	range_bounds_set.iter().collect::<Vec<_>>(),
-	/// 	[&(8..100)]
-	/// );
+	/// assert_eq!(set.iter().collect::<Vec<_>>(), [&(8..100)]);
 	/// ```
 	#[trivial]
 	pub fn remove_overlapping<Q>(
@@ -499,7 +493,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
 	/// 	.unwrap();
 	///
-	/// let mut gaps = range_bounds_set.gaps(&(2..));
+	/// let mut gaps = set.gaps(&(2..));
 	///
 	/// assert_eq!(
 	/// 	gaps.collect::<Vec<_>>(),
@@ -540,7 +534,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
 	/// 	.unwrap();
 	///
-	/// let mut gaps_same = range_bounds_set.gaps_same(&(2..));
+	/// let mut gaps_same = set.gaps_same(&(2..));
 	///
 	/// assert_eq!(
 	/// 	gaps_same.collect::<Vec<_>>(),
@@ -576,15 +570,9 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..3, 5..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// assert_eq!(range_bounds_set.contains_range_bounds(&(1..3)), true);
-	/// assert_eq!(
-	/// 	range_bounds_set.contains_range_bounds(&(2..6)),
-	/// 	false
-	/// );
-	/// assert_eq!(
-	/// 	range_bounds_set.contains_range_bounds(&(6..50)),
-	/// 	true
-	/// );
+	/// assert_eq!(set.contains_range_bounds(&(1..3)), true);
+	/// assert_eq!(set.contains_range_bounds(&(2..6)), false);
+	/// assert_eq!(set.contains_range_bounds(&(6..50)), true);
 	/// ```
 	#[trivial]
 	pub fn contains_range_bounds<Q>(&self, range_bounds: &Q) -> bool
@@ -624,27 +612,18 @@ where
 	/// let mut set = RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
-	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_touching(4..6),
-	/// 	Ok(&(1..6))
-	/// );
+	/// assert_eq!(set.insert_merge_touching(4..6), Ok(&(1..6)));
 	///
 	/// // Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_touching(4..8),
+	/// 	set.insert_merge_touching(4..8),
 	/// 	Err(OverlapOrTryFromBoundsError::Overlap(OverlapError)),
 	/// );
 	///
 	/// // Neither Touching or Overlapping
-	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_touching(10..16),
-	/// 	Ok(&(10..16))
-	/// );
+	/// assert_eq!(set.insert_merge_touching(10..16), Ok(&(10..16)));
 	///
-	/// assert_eq!(
-	/// 	range_bounds_set.iter().collect::<Vec<_>>(),
-	/// 	[&(1..6), &(10..16)]
-	/// );
+	/// assert_eq!(set.iter().collect::<Vec<_>>(), [&(1..6), &(10..16)]);
 	/// ```
 	#[trivial]
 	pub fn insert_merge_touching(
@@ -681,25 +660,16 @@ where
 	/// let mut set = RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
-	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_overlapping(-4..1),
-	/// 	Ok(&(-4..1))
-	/// );
+	/// assert_eq!(set.insert_merge_overlapping(-4..1), Ok(&(-4..1)));
 	///
 	/// // Overlapping
-	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_overlapping(2..8),
-	/// 	Ok(&(1..8))
-	/// );
+	/// assert_eq!(set.insert_merge_overlapping(2..8), Ok(&(1..8)));
 	///
 	/// // Neither Touching or Overlapping
-	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_overlapping(10..16),
-	/// 	Ok(&(10..16))
-	/// );
+	/// assert_eq!(set.insert_merge_overlapping(10..16), Ok(&(10..16)));
 	///
 	/// assert_eq!(
-	/// 	range_bounds_set.iter().collect::<Vec<_>>(),
+	/// 	set.iter().collect::<Vec<_>>(),
 	/// 	[&(-4..1), &(1..8), &(10..16)]
 	/// );
 	/// ```
@@ -739,26 +709,23 @@ where
 	///
 	/// // Touching
 	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_touching_or_overlapping(-4..1),
+	/// 	set.insert_merge_touching_or_overlapping(-4..1),
 	/// 	Ok(&(-4..4))
 	/// );
 	///
 	/// // Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_touching_or_overlapping(2..8),
+	/// 	set.insert_merge_touching_or_overlapping(2..8),
 	/// 	Ok(&(-4..8))
 	/// );
 	///
 	/// // Neither Touching or Overlapping
 	/// assert_eq!(
-	/// 	range_bounds_set.insert_merge_touching_or_overlapping(10..16),
+	/// 	set.insert_merge_touching_or_overlapping(10..16),
 	/// 	Ok(&(10..16))
 	/// );
 	///
-	/// assert_eq!(
-	/// 	range_bounds_set.iter().collect::<Vec<_>>(),
-	/// 	[&(-4..8), &(10..16)]
-	/// );
+	/// assert_eq!(set.iter().collect::<Vec<_>>(), [&(-4..8), &(10..16)]);
 	/// ```
 	#[trivial]
 	pub fn insert_merge_touching_or_overlapping(
@@ -795,10 +762,10 @@ where
 	///
 	/// let mut set = RangeBoundsSet::from_slice_strict([2..8]).unwrap();
 	///
-	/// assert_eq!(range_bounds_set.insert_overwrite(4..6), Ok(()));
+	/// assert_eq!(set.insert_overwrite(4..6), Ok(()));
 	///
 	/// assert_eq!(
-	/// 	range_bounds_set.iter().collect::<Vec<_>>(),
+	/// 	set.iter().collect::<Vec<_>>(),
 	/// 	[&(2..4), &(4..6), &(6..8)]
 	/// );
 	/// ```
@@ -822,7 +789,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// assert_eq!(range_bounds_set.first(), Some(&(1..4)));
+	/// assert_eq!(set.first(), Some(&(1..4)));
 	/// ```
 	#[trivial]
 	pub fn first(&self) -> Option<&K> {
@@ -838,7 +805,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// assert_eq!(range_bounds_set.last(), Some(&(8..100)));
+	/// assert_eq!(set.last(), Some(&(8..100)));
 	/// ```
 	#[trivial]
 	pub fn last(&self) -> Option<&K> {
@@ -959,8 +926,7 @@ where
 	/// let set = RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
 	/// 	.unwrap();
 	///
-	/// let mut overlapping_trimmed =
-	/// 	range_bounds_set.overlapping_trimmed(&(2..20));
+	/// let mut overlapping_trimmed = set.overlapping_trimmed(&(2..20));
 	///
 	/// assert_eq!(
 	/// 	overlapping_trimmed.collect::<Vec<_>>(),
@@ -1001,7 +967,7 @@ where
 	/// 	.unwrap();
 	///
 	/// let mut overlapping_trimmed_same =
-	/// 	range_bounds_set.overlapping_trimmed_same(&(2..=20));
+	/// 	set.overlapping_trimmed_same(&(2..=20));
 	///
 	/// assert_eq!(
 	/// 	overlapping_trimmed_same.collect::<Vec<_>>(),

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -995,9 +995,8 @@ where
 	/// from the slice into the set using
 	/// [`RangeBoundsSet::insert_strict()`].
 	///
-	/// If any of the given `RangeBounds` overlap any of the other
-	/// `RangeBounds` in the slice, then an [`OverlapError`] is
-	/// returned.
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsSet::insert_strict()`] for details.
 	///
 	/// # Panics
 	///
@@ -1019,7 +1018,157 @@ where
 	) -> Result<RangeBoundsSet<I, K>, OverlapError> {
 		let mut set = RangeBoundsSet::new();
 		for range_bounds in slice {
-			set.insert_strict(range_bounds).unwrap();
+			set.insert_strict(range_bounds)?;
+		}
+		return Ok(set);
+	}
+	/// Allocate a `RangeBoundsSet` and move the given `RangeBounds`
+	/// from the slice into the set using
+	/// [`RangeBoundsSet::insert_merge_touching()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsSet::insert_merge_touching()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
+	///
+	/// let set = RangeBoundsSet::from_slice_merge_touching([
+	/// 	1..4,
+	/// 	4..8,
+	/// 	8..100,
+	/// ])
+	/// .unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_merge_touching<const N: usize>(
+		slice: [K; N],
+	) -> Result<RangeBoundsSet<I, K>, OverlapOrTryFromBoundsError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut set = RangeBoundsSet::new();
+		for range_bounds in slice {
+			set.insert_merge_touching(range_bounds)?;
+		}
+		return Ok(set);
+	}
+	/// Allocate a `RangeBoundsSet` and move the given `RangeBounds`
+	/// from the slice into the set using
+	/// [`RangeBoundsSet::insert_merge_overlapping()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsSet::insert_merge_overlapping()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
+	///
+	/// let set = RangeBoundsSet::from_slice_merge_overlapping([
+	/// 	1..4,
+	/// 	4..8,
+	/// 	8..100,
+	/// ])
+	/// .unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_merge_overlapping<const N: usize>(
+		slice: [K; N],
+	) -> Result<RangeBoundsSet<I, K>, TryFromBoundsError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut set = RangeBoundsSet::new();
+		for range_bounds in slice {
+			set.insert_merge_overlapping(range_bounds)?;
+		}
+		return Ok(set);
+	}
+	/// Allocate a `RangeBoundsSet` and move the given `RangeBounds`
+	/// from the slice into the set using
+	/// [`RangeBoundsSet::insert_merge_touching_or_overlapping()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsSet::insert_merge_touching_or_overlapping()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
+	///
+	/// let set =
+	/// 	RangeBoundsSet::from_slice_merge_touching_or_overlapping([
+	/// 		1..4,
+	/// 		4..8,
+	/// 		8..100,
+	/// 	])
+	/// 	.unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_merge_touching_or_overlapping<const N: usize>(
+		slice: [K; N],
+	) -> Result<RangeBoundsSet<I, K>, TryFromBoundsError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut set = RangeBoundsSet::new();
+		for range_bounds in slice {
+			set.insert_merge_touching_or_overlapping(range_bounds)?;
+		}
+		return Ok(set);
+	}
+	/// Allocate a `RangeBoundsSet` and move the given `RangeBounds`
+	/// from the slice into the set using
+	/// [`RangeBoundsSet::insert_overwrite()`].
+	///
+	/// May return an `Err` while inserting. See
+	/// [`RangeBoundsSet::insert_overwrite()`] for details.
+	///
+	/// # Panics
+	///
+	/// Panics if any of the given `RangeBounds` is an invalid
+	/// `RangeBounds`. See [`Invalid
+	/// RangeBounds`](https://docs.rs/range_bounds_map/latest/range_bounds_map/index.html#Invalid-RangeBounds)
+	/// for more details.
+	///
+	/// # Examples
+	/// ```
+	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
+	///
+	/// let set =
+	/// 	RangeBoundsSet::from_slice_overwrite([1..4, 4..8, 8..100])
+	/// 		.unwrap();
+	/// ```
+	#[trivial]
+	pub fn from_slice_overwrite<const N: usize>(
+		slice: [K; N],
+	) -> Result<RangeBoundsSet<I, K>, TryFromBoundsError>
+	where
+		K: TryFromBounds<I>,
+	{
+		let mut set = RangeBoundsSet::new();
+		for range_bounds in slice {
+			set.insert_overwrite(range_bounds)?;
 		}
 		return Ok(set);
 	}

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -1050,7 +1050,7 @@ where
 	) -> Result<RangeBoundsSet<I, K>, OverlapError> {
 		let mut set = RangeBoundsSet::new();
 		for range_bounds in slice {
-			set.insert_strict(range_bounds);
+			set.insert_strict(range_bounds).unwrap();
 		}
 		return Ok(set);
 	}

--- a/src/range_bounds_set.rs
+++ b/src/range_bounds_set.rs
@@ -46,7 +46,8 @@ use crate::{
 ///
 /// // Make a new set
 /// let mut set =
-/// 	RangeBoundsSet::try_from([4..8, 8..18, 20..100]).unwrap();
+/// 	RangeBoundsSet::from_slice_strict([4..8, 8..18, 20..100])
+/// 		.unwrap();
 ///
 /// if set.contains_point(&99) {
 /// 	println!("Set contains value at 99 :)");
@@ -256,7 +257,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let mut overlapping = range_bounds_set.overlapping(&(2..8));
 	///
@@ -284,7 +286,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.get_at_point(&3), Some(&(1..4)));
 	/// assert_eq!(range_bounds_set.get_at_point(&4), Some(&(4..8)));
@@ -303,7 +306,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.contains_point(&3), true);
 	/// assert_eq!(range_bounds_set.contains_point(&4), true);
@@ -322,7 +326,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let mut iter = range_bounds_set.iter();
 	///
@@ -351,7 +356,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let mut removed = range_bounds_set.remove_overlapping(&(2..8));
 	///
@@ -397,10 +403,11 @@ where
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
 	/// let mut base =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let after_cut =
-	/// 	RangeBoundsSet::try_from([1..2, 40..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..2, 40..100]).unwrap();
 	///
 	/// assert_eq!(
 	/// 	base.cut(&(2..40)).unwrap().collect::<Vec<_>>(),
@@ -443,10 +450,11 @@ where
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
 	/// let mut base =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let after_cut =
-	/// 	RangeBoundsSet::try_from([1..2, 40..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..2, 40..100]).unwrap();
 	///
 	/// assert_eq!(
 	/// 	base.cut_same(&(2..40)).unwrap().collect::<Vec<_>>(),
@@ -494,7 +502,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..3, 5..7, 9..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
+	/// 		.unwrap();
 	///
 	/// let mut gaps = range_bounds_set.gaps(&(2..));
 	///
@@ -535,7 +544,8 @@ where
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..3, 5..7, 9..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..3, 5..7, 9..100])
+	/// 		.unwrap();
 	///
 	/// let mut gaps_same = range_bounds_set.gaps_same(&(2..));
 	///
@@ -571,7 +581,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..3, 5..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..3, 5..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.contains_range_bounds(&(1..3)), true);
 	/// assert_eq!(
@@ -619,7 +630,7 @@ where
 	/// };
 	///
 	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -677,7 +688,7 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -735,7 +746,7 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4]).unwrap();
 	///
 	/// // Touching
 	/// assert_eq!(
@@ -794,7 +805,7 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let mut range_bounds_set =
-	/// 	RangeBoundsSet::try_from([2..8]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([2..8]).unwrap();
 	///
 	/// assert_eq!(range_bounds_set.insert_overwrite(4..6), Ok(()));
 	///
@@ -821,7 +832,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.first(), Some(&(1..4)));
 	/// ```
@@ -837,7 +849,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// assert_eq!(range_bounds_set.last(), Some(&(8..100)));
 	/// ```
@@ -859,13 +872,19 @@ where
 	/// ```
 	/// use range_bounds_map::RangeBoundsSet;
 	///
-	/// let mut base = RangeBoundsSet::try_from([1..4, 4..8]).unwrap();
+	/// let mut base =
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8]).unwrap();
 	///
-	/// let mut add = RangeBoundsSet::try_from([10..38, 40..42]).unwrap();
+	/// let mut add =
+	/// 	RangeBoundsSet::from_slice_strict([10..38, 40..42]).unwrap();
 	///
-	/// let expected =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 10..38, 40..42])
-	/// 		.unwrap();
+	/// let expected = RangeBoundsSet::from_slice_strict([
+	/// 	1..4,
+	/// 	4..8,
+	/// 	10..38,
+	/// 	40..42,
+	/// ])
+	/// .unwrap();
 	///
 	/// assert_eq!(base.append_strict(&mut add), Ok(()));
 	/// assert_eq!(base, expected);
@@ -876,12 +895,13 @@ where
 		&mut self,
 		other: &mut RangeBoundsSet<I, K>,
 	) -> Result<(), OverlapError> {
-		self.map.append_strict(
-			&mut other
-				.remove_overlapping(&(Bound::Unbounded::<I>, Bound::Unbounded))
-				.map(|key| (key, ()))
-				.collect(),
-		)
+		for range_bounds in
+			other.remove_overlapping(&(Bound::Unbounded::<I>, Bound::Unbounded))
+		{
+			self.insert_strict(range_bounds)?;
+		}
+
+		return Ok(());
 	}
 
 	/// Splits the set in two at the given `start_bound()`. Returns
@@ -899,7 +919,8 @@ where
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
 	/// let mut a =
-	/// 	RangeBoundsSet::try_from([1..2, 4..8, 10..16]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..2, 4..8, 10..16])
+	/// 		.unwrap();
 	///
 	/// // Fails because that would leave an Inclusive-Inclusive
 	/// // `RangeBounds` in `a`
@@ -921,9 +942,12 @@ where
 	where
 		K: TryFromBounds<I> + Clone,
 	{
-		self.map
-			.split_off(start_bound)
-			.map(|map| map.into_iter().map(first).collect())
+		let mut set = RangeBoundsSet::new();
+		for (range_bounds, _) in self.map.split_off(start_bound)? {
+			set.insert_strict(range_bounds).unwrap();
+		}
+
+		Ok(set)
 	}
 
 	/// Similar to [`RangeBoundsSet::overlapping()`] except the
@@ -947,7 +971,8 @@ where
 	/// use range_bounds_map::RangeBoundsSet;
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let mut overlapping_trimmed =
 	/// 	range_bounds_set.overlapping_trimmed(&(2..20));
@@ -988,7 +1013,8 @@ where
 	/// use range_bounds_map::{RangeBoundsSet, TryFromBoundsError};
 	///
 	/// let range_bounds_set =
-	/// 	RangeBoundsSet::try_from([1..4, 4..8, 8..100]).unwrap();
+	/// 	RangeBoundsSet::from_slice_strict([1..4, 4..8, 8..100])
+	/// 		.unwrap();
 	///
 	/// let mut overlapping_trimmed_same =
 	/// 	range_bounds_set.overlapping_trimmed_same(&(2..=20));
@@ -1013,6 +1039,20 @@ where
 		K: TryFromBounds<I>,
 	{
 		self.map.overlapping_trimmed_same(range_bounds).map(first)
+	}
+
+	/// Allocate a `RangeBoundsSet` and move the given `RangeBounds`
+	/// in the slice into the set using
+	/// [`RangeBoundsMap::insert_strict()`].
+	#[trivial]
+	pub fn from_slice_strict<const N: usize>(
+		slice: [K; N],
+	) -> Result<RangeBoundsSet<I, K>, OverlapError> {
+		let mut set = RangeBoundsSet::new();
+		for range_bounds in slice {
+			set.insert_strict(range_bounds);
+		}
+		return Ok(set);
 	}
 }
 

--- a/todo.md
+++ b/todo.md
@@ -20,6 +20,10 @@
 
 - replace `RangeBounds` with `K` where applicatble in docs
 - replace rust types URL links with direct rust links
+- normalize the description of the project beteen:
+  - the first line of the crate levele docs/readme
+  - the description meta-data section on github
+  - the descriptio meta-data field in the Cargo.toml
 
 # features
 


### PR DESCRIPTION
fixes #10

This is the second and hopefully final attempt.